### PR TITLE
Add secrets management to task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ No modules.
 | <a name="input_scale_out_statistic"></a> [scale\_out\_statistic](#input\_scale\_out\_statistic) | The statistic for scaling out | `string` | `"Average"` | no |
 | <a name="input_scale_requests_tracking"></a> [scale\_requests\_tracking](#input\_scale\_requests\_tracking) | The name of the requests tracking resource | `number` | `30` | no |
 | <a name="input_scale_type"></a> [scale\_type](#input\_scale\_type) | The scale type for the task definition | `string` | n/a | yes |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | Secret Manager or Parameter Store list of secrets | <pre>list(object({<br/>    name      = string<br/>    valueFrom = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_service_cpu"></a> [service\_cpu](#input\_service\_cpu) | The number of CPU units to reserve for the service | `number` | n/a | yes |
 | <a name="input_service_healthcheck"></a> [service\_healthcheck](#input\_service\_healthcheck) | The healthcheck for the service | `map(string)` | n/a | yes |
 | <a name="input_service_hosts"></a> [service\_hosts](#input\_service\_hosts) | The hosts for the service | `list(string)` | n/a | yes |

--- a/iam_role.tf
+++ b/iam_role.tf
@@ -47,6 +47,7 @@ resource "aws_iam_role_policy" "service_execution_policy" {
           "logs:CreateLogStream",
           "logs:PutLogEvents",
           "ssm:GetParameters",
+          "secretsmanager:GetSecretValue",
         ],
         Resource = "*"
       }

--- a/task_definition.tf
+++ b/task_definition.tf
@@ -17,7 +17,8 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
     for_each = var.efs_volumes
 
     content {
-      name = volume.value.volume_name
+      configure_at_launch = false
+      name                = volume.value.volume_name
 
       efs_volume_configuration {
         file_system_id          = volume.value.file_system_id
@@ -36,6 +37,7 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
       memory      = var.service_memory
       essential   = true
       environment = var.environment_variables
+      secrets     = var.secrets
 
       portMappings = [
         {

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,15 @@ variable "environment_variables" {
   }))
 }
 
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Secret Manager or Parameter Store list of secrets"
+  default     = []
+}
+
 variable "capabilities" {
   description = "The capabilities for the task definition"
   type        = list(string)


### PR DESCRIPTION
Introduce a secrets variable to support secrets management in the task definition and update the IAM policy to allow access to secret values.